### PR TITLE
Add a way to generate output file using argparse.

### DIFF
--- a/src/spiderman.py
+++ b/src/spiderman.py
@@ -19,14 +19,10 @@ def main(stdscr) -> None:
     args:argparse.Namespace = get_argparse()
     input_file:str = args.input_file
     root_directory_name:str = args.root_directory
+    output_file:str = args.output_file
 
     project_root = get_parent_path()
     input_file = project_root / "data" / input_file
-    output_file = project_root / "directory_tree.txt"
-
-    # TODO: The following line is not actually used yet, but will be once the program has different
-    #   ways to 'start' the program.
-    check_for_output_file(output_file)
 
     # TODO: eventually, this will need to be changed to checking if a directory is already populated
     #   for now, this will just be the entry point.
@@ -36,11 +32,13 @@ def main(stdscr) -> None:
     # Populating the root directory.
     main_directory_asset = instantiate_directory_object(parent_directory_name=root_directory_name, directory_list=directories)
 
-    stdscr.addstr(0,0, f"{type(stdscr)}")
-    stdscr.refresh()
-
-    # Entering the main loop.
-    navigator = DirectoryNavigator(main_directory_asset, stdscr)
+    # if output_file was provided, then generate outputfile. Otherwise run main loop.
+    if output_file:
+        print("Inside of output_file running")
+        print(f"Trying to save to {output_file}")
+        main_directory_asset.create_output_file(output_file_name=output_file)
+    else:
+        navigator = DirectoryNavigator(main_directory_asset, stdscr)
 
 
 def get_argparse() -> argparse.Namespace:
@@ -76,6 +74,10 @@ def get_argparse() -> argparse.Namespace:
                         default="/"
                         )
 
+    parser.add_argument("-o", "--output_file",
+                        help="The output file for the tree. If used, the program does not run interactive directory building.",
+                        default=None)
+
     return parser.parse_args()
 
 
@@ -88,15 +90,6 @@ def get_parent_path() -> "PosixPath":
     script_path = Path(__file__).resolve()
     project_root = script_path.parent.parent
     return project_root
-
-
-def check_for_output_file(output_file:"PosixPath"):
-    """Not currently used.
-
-    When used, this will check for an output file. If it exists, then it will load the data.
-    """
-    # TODO: Check if user wants to load data, then do some validation and loading
-    return output_file.resolve().exists()
 
 
 def instantiate_directory_object(parent_directory_name, directory_list) -> DirectoryAsset:


### PR DESCRIPTION
In spiderman.py, added a way to provide an outputfile. If the output file is provided, then the interactive directory builder is not evoked.

Resolves #4 