### PR TITLE
Feature empty directory

### DIFF
--- a/src/directory_navigator.py
+++ b/src/directory_navigator.py
@@ -117,7 +117,14 @@ class DirectoryNavigator:
         """
         self.stdscr.clear()
 
-        directory_list = self.current_directory.get_asset_list()
+        try:
+            directory_list = self.current_directory.get_asset_list()
+        except IndexError as e:
+            self.stdscr.addstr(0, 0, str(e), self.RED_ALERT)
+            exit_banner = "Press ENTER ..."
+            self.stdscr.addstr(1, 0, exit_banner)
+            self.stdscr.getch(1, len(exit_banner))
+            return  # exit this function
 
         last_available_line = curses.LINES - 1
 

--- a/src/spiderman.py
+++ b/src/spiderman.py
@@ -123,4 +123,8 @@ def instantiate_directory_object(parent_directory_name, directory_list) -> Direc
 
 
 if __name__ == "__main__":
+    # Not super efficient, but calling args before curses is called.
+    # This way, help can be ran before curses takes over stdout.
+    # Args will also be called inside of main.
+    args = get_argparse()
     curses.wrapper(main)


### PR DESCRIPTION
Closes #6 

Allows a user to start the program with an empty directory using the -e switch from the CLI.

When running -e, it ignores -i and -o, and runs directory_navigator with an empty directory.