### PR TITLE
Quick quit showing directory tree.

### DIFF
--- a/src/directory_navigator.py
+++ b/src/directory_navigator.py
@@ -141,12 +141,15 @@ class DirectoryNavigator:
                 # due to the else statement still incrementing index
                 self.stdscr.addstr(current_print_line, 0, directory_list[index])
                 self.stdscr.addstr(last_available_line, 0, 
-                                   f"{index + 1} out of {len(directory_list)} directories printed. Print any key to continue.", 
+                                   f"{index + 1} out of {len(directory_list)} directories printed. Print any key to continue or q to quit.", 
                                    curses.A_REVERSE
                                    )
                 self.stdscr.refresh()
                 current_print_line = 0
-                self.stdscr.getch()
+                # If user's key input is q, then quit
+                if self.stdscr.getkey().lower() == "q":
+                    self.stdscr.clear()
+                    return
                 self.stdscr.clear()
 
         self.stdscr.addstr(last_available_line, 0,


### PR DESCRIPTION
Added a way for the user to quit the directory_navigator.show_current_directory_tree() early so they don't have to shift through all the values to exit.
Resolves #9 