### PR TITLE
Prevent user from creating directories with already existing names.

### DIFF
--- a/src/directory_asset.py
+++ b/src/directory_asset.py
@@ -20,6 +20,18 @@ class DirectoryAsset():
         :param children: A dictionary containing the child's name, and the child DirectoryAsset object.
         :type children: dict[str, DirectoryAsset]
         """
+        # Checking if the directory already exists. If so, raise an error.
+        try:
+            directory_index = [directory.name for directory in DirectoryAsset.master_list].index(name)
+        except ValueError:
+            pass
+        else:
+            # If the parent has a name, then show it. Otherwise, just tell user the directory already exists.
+            if DirectoryAsset.master_list[directory_index].parent:
+                raise ValueError(f"[!] Cannot create {name} - it already exists as a parent to {DirectoryAsset.master_list[directory_index].parent.name}")
+            else:
+                raise ValueError(f"[!] Cannot create {name} - it already exists as a directory.")
+
         self.name = name
         self.level = level
         self.parent = parent
@@ -63,8 +75,14 @@ class DirectoryAsset():
                 directories_to_add.add(directory)
 
         for directory in directories_to_add:
-            child_directory = DirectoryAsset(directory, level=self.level+2, parent=self)
-            self.add_child(child_directory)  # this creates the dictionary entry for children
+            # Ignore ValueErrors raised by object creation if the directory already exists.
+            # Removing the try/except block will cause errors when trying to bulk add entries.
+            try:
+                child_directory = DirectoryAsset(directory, level=self.level+2, parent=self)
+            except ValueError:
+                pass
+            else:
+                self.add_child(child_directory)  # this creates the dictionary entry for children
 
     def add_child(self, child:"DirectoryAsset"=None) -> None:
         """Add a single child to self.
@@ -72,6 +90,7 @@ class DirectoryAsset():
         :param child: The DirectoryAsset to as a child to self. Defaults to None.
         :type child: DirectoryAsset
         """
+
         child.parent_directory = self
 
         self.children.setdefault(child.name, child)  # adding child as directory

--- a/src/directory_navigator.py
+++ b/src/directory_navigator.py
@@ -216,13 +216,20 @@ class DirectoryNavigator:
         self.stdscr.addstr(1, 0, input_message)
 
         child_name = self.stdscr.getstr(1, len(input_message)).decode()
-        child = DirectoryAsset(name=child_name, parent=self.current_directory, level=self.current_directory.level+2)
-        self.current_directory.add_child(child)
+        try:
+            child = DirectoryAsset(name=child_name, parent=self.current_directory, level=self.current_directory.level+2)
+        except ValueError as e:
+            self.stdscr.addstr(2, 0, str(e), self.RED_ALERT)
+            closing_message = "Nothing happened. Press ENTER ..."
+            self.stdscr.addstr(3, 0, closing_message)
+            self.stdscr.getch(3, len(closing_message))
+        else:
+            self.current_directory.add_child(child)
 
-        self.stdscr.addstr(2, 0, f"[+] {child_name} has been added to {self.current_directory.name}", self.GREEN_ALERT)
-        closing_message = "Press ENTER ..."
-        self.stdscr.addstr(3, 0, closing_message)
-        self.stdscr.getch(3, len(closing_message))
+            self.stdscr.addstr(2, 0, f"[+] {child_name} has been added to {self.current_directory.name}", self.GREEN_ALERT)
+            closing_message = "Press ENTER ..."
+            self.stdscr.addstr(3, 0, closing_message)
+            self.stdscr.getch(3, len(closing_message))
 
     def change_directory(self) -> None:
         """Changes the current_directory attribute.


### PR DESCRIPTION
Added try/except block to object creation for directory_asset that throws an error if the directory trying to be created with the same name. Try blocks have been added to appropriate areas in directory_asset and directory_navigator to catch these errors and handle appropriately.