### PR TITLE
Fix Ctrl+C handling in curses UI 

### DIFF
--- a/src/directory_navigator.py
+++ b/src/directory_navigator.py
@@ -124,7 +124,12 @@ class DirectoryNavigator:
 
             self.stdscr.refresh()
 
-            key = self.stdscr.getkey()
+            try:
+                key = self.stdscr.getkey()
+            except KeyboardInterrupt:
+                # Ctrl+C at main menu → exit program
+                raise
+
 
             if key in ["j", "KEY_DOWN"] and current_line < max_option:
                 current_line += 1
@@ -207,7 +212,11 @@ class DirectoryNavigator:
             self.stdscr.noutrefresh()
             treepad.noutrefresh(shown_lines, 0, 1, 0, max_line, max_col)
             curses.doupdate()
-            key = treepad.getkey()
+            try:
+                key = treepad.getkey()
+            except KeyboardInterrupt:
+                return
+
             # if user presses j or KEY_DOWN, then move the screen down a whole screen
             if key in ["j", "KEY_DOWN"]:
                 self.stdscr.clear()
@@ -245,7 +254,11 @@ class DirectoryNavigator:
         # Get the file name.
         input_banner = f"[+] Please enter the name of the file to populate the current directory: "
         col_length = self.show_banner(1, 0, input_banner, reverse=False)
-        file_name:str = self.stdscr.getstr(1, col_length).decode()
+        try:
+            file_name:str = self.stdscr.getstr(1, col_length).decode()
+        except KeyboardInterrupt:
+            return
+
 
         try:
             input_file = get_datafile(file_name)  # function from directory_asset


### PR DESCRIPTION
Summary:
This PR fixes Ctrl+C behavior in the curses-based UI so it behaves contextually and exits cleanly.
Pressing Ctrl+C inside a submenu or prompt now aborts the current action and returns to the main menu.
Pressing Ctrl+C at the main menu now exits the program cleanly, with the terminal restored.
This matches the behavior described in Issue #52.


What was wrong:
Previously, KeyboardInterrupt raised by curses.getkey(), getstr(), or getch() was not handled consistently. As a result:
Ctrl+C could crash the curses session
Terminal state was sometimes left in a broken state
There was no distinction between main menu and submenu context


What this PR changes:
Submenu input calls (getkey, getstr, getch) now catch KeyboardInterrupt locally and return to the main menu.
The main menu input re-raises KeyboardInterrupt, allowing curses.wrapper() to restore terminal state and exit cleanly.
No changes were made to the program entry point (curses.wrapper(main)), as it already handles cleanup correctly.

Files changed
src/directory_navigator.py
Added contextual KeyboardInterrupt handling:
return in submenus
raise at the main menu

Notes
Tested in WSL due to curses dependency.
No behavior changes outside Ctrl+C handling.

Related issue
Fixes #52